### PR TITLE
Calculation Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ If it doesn't seem to know which project of yours to deploy to, or your account 
 interactive setup for gcloud. Run `gcloud init` to revisit that setup.
 
 Once the project is in production, you can kick off scraping by visiting `myproject.appspot.com/start`. You can monitor
-the task queue (and purge it) in the [Cloud Console](https://console.cloud.google.com/appengine/taskqueues?project=recidiviz-123&serviceId=default&tab=PUSH),
-and read the service logs there [as well](https://console.cloud.google.com/logs/viewer?project=recidiviz-123&minLogLevel=0&expandAll=false).
+the task queue (and purge it) in the Cloud Console, and read the service logs there as well.
 
 **_(Note: Don't test in prod unless you really mean it! It will try to crawl production data systems at 1qps at the
 moment, which may impact actual operations. We strongly recommend developing only with the local dev server, which you

--- a/calculator/README.md
+++ b/calculator/README.md
@@ -96,4 +96,4 @@ approximation of overall recidivism. But the number can provide a sanity check: 
 percentage of `total_records_reduced`, maybe somewhere around 15%-40% depending on region.
 
 Logs are printed via stdout by default for the local development server. In production, logs can be read
-[here](https://console.cloud.google.com/logs/viewer?project=recidiviz-123&minLogLevel=0&expandAll=false).
+in the Cloud Console.

--- a/calculator/calculator.py
+++ b/calculator/calculator.py
@@ -33,6 +33,186 @@ from scraper.us_ny.us_ny_record import UsNyRecord
 FOLLOW_UP_PERIODS = range(1, 11)
 
 
+# ============================================================================= #
+# Phase 1: Transform raw records into instances of recidivism or non-recidivism #
+# ============================================================================= #
+
+def find_recidivism(inmate, include_conditional_violations=False):
+    """
+    Classifies all individual sentences for the inmate as either leading to recidivism or not.
+    Transforms each sentence from which the inmate has been released into a mapping from its
+    release cohort to the details of the event. The release cohort is an integer for the year,
+    e.g. 2006. The event details are a RecidivismEvent object, which represents events of both
+    recidivism and non-recidivism. That is, each inmate sentence is transformed into a
+    recidivism event unless it is the most recent sentence and they are still incarcerated.
+
+    Example output for someone who went to prison in 2006, was released in 2008, went back in 2010,
+    was released in 2012, and never returned:
+    {
+      2008: RecidivismEvent(recidivated=True, original_entry_date="2006-04-05", ...),
+      2012: RecidivismEvent(recidivated=False, original_entry_date="2010-09-17", ...)
+    }
+
+    :param inmate: an inmate to determine recidivism for
+    :param include_conditional_violations: whether or not to include violations of conditional
+    release as recidivism events
+    :return: a dictionary from release cohorts to recidivism events for the given inmate in
+    that cohort. No more than one event can be returned per release cohort per inmate.
+    """
+    records = Record.query(ancestor=inmate.key).order(Record.custody_date).fetch()
+    snapshots = InmateFacilitySnapshot.query(ancestor=inmate.key).order(-InmateFacilitySnapshot.snapshot_date).fetch()
+
+    recidivism_events = {}
+
+    for index, record in enumerate(records):
+        record_id = record.key.id()
+
+        original_entry_date = first_entrance(record)
+
+        if original_entry_date is None:
+            # If there is no entry date on the record, there is nothing we can process. Skip it.
+            # See Issue #49.
+            continue
+
+        if record.is_released and not record.last_release_date:
+            # If the record is marked as released but there is no release date, there is nothing we
+            # can process. Skip it. See Issue #51.
+            continue
+
+        release_date = final_release(record)
+        release_cohort = release_date.year if release_date else None
+        release_facility = last_facility(record, snapshots)
+
+        # If this is their last (or only) record, then they did not recidivate for this one!
+        if len(records) - index == 1:
+            # There is only something to calculate if they are out of prison from this last record
+            if record.is_released:
+                logging.debug("Inmate was released from last or only record %s. No recidivism." %
+                              record_id)
+                recidivism_events[release_cohort] = RecidivismEvent.non_recidivism_event(
+                    original_entry_date, release_date, release_facility)
+            else:
+                logging.debug("Inmate is still incarcerated for last or only record %s. Nothing to track" %
+                              record_id)
+
+        else:
+            # If there is a record after this one and they have been released, then they
+            # recidivated. Capture the details.
+            if record.is_released:
+                logging.debug("Inmate was released from record %s and went back again. Yes recidivism." %
+                              record_id)
+
+                later_records = records[index+1:]
+
+                recidivism_record = later_records[0]
+                reincarceration_date = first_entrance(recidivism_record)
+                reincarceration_facility = first_facility(recidivism_record, snapshots)
+
+                # If the release from the original sentence was final, i.e. was an unconditional
+                # release or a conditional release which was never revoked, then this is a
+                # relatively simple case of being released from prison and returning for a new
+                # crime: recidivism.
+                sole_release = was_released_only_once(record)
+
+                # However, if the release was conditional and it was revoked, e.g. a parole violation,
+                # prior to the final release then we want to capture that intermediate "recidivism"
+                # event for specific metrics.
+                if include_conditional_violations and not sole_release:
+                    intermediate_release_date = None  # TODO See Issue #34
+                    intermediate_release_cohort = intermediate_release_date.year
+                    re_entrance = subsequent_entrance(record)
+
+                    recidivism_events[intermediate_release_cohort] = RecidivismEvent.recidivism_event(
+                        original_entry_date, intermediate_release_date, release_facility,
+                        re_entrance, release_facility, True)
+
+                recidivism_events[release_cohort] = RecidivismEvent.recidivism_event(
+                    original_entry_date, release_date, release_facility,
+                    reincarceration_date, reincarceration_facility, False)
+
+    return recidivism_events
+
+
+def first_entrance(record):
+    """
+    The first entrance is when an inmate first when to prison for a new sentence. An inmate may
+    be conditionally released and returned to prison on violation of conditions for the same
+    sentence, yielding a subsequent entrance date.
+
+    :param record: a single record
+    :return: when the inmate first entered into prison for this record
+    """
+    return record.custody_date
+
+
+def subsequent_entrance(record):
+    """
+    A subsequent entrance is when an inmate returns to prison for a given sentence, after having
+    already been conditionally for that same sentence. It is not returning to prison for a brand
+    new sentence.
+
+    :param record: a single record
+    :return: when the inmate re-entered prison for this record
+    """
+    return record.last_custody_date
+
+
+def final_release(record):
+    """
+    The release cohort is the year in which an inmate was released from prison for a particular
+    sentence. This is used to normalize recidivism calculation, e.g. calculating and comparing
+    recidivism for all inmates released in a particular calendar year.
+
+    :param record: a single record
+    :return: None if the inmate is still in custody, otherwise the final release of this record,
+    from which release cohort can be derived
+    """
+    if not record.is_released:
+        return None
+
+    return record.last_release_date
+
+
+def first_facility(record, inmate_snapshots):
+    """
+    Returns the facility that the inmate was first in for the given record. That is, the facility that
+    they started that record in, whether or not they have since been released.
+
+    This assumes the snapshots are provided in descending order by snapshot date, i.e. it picks the
+    facility in the last snapshot in the collection that matches the given record.
+
+    :param record: a single record
+    :param inmate_snapshots: all facility snapshots for the inmate
+    :return: the facility that the inmate first occupied for the record
+    """
+    return last_facility(record, reversed(inmate_snapshots))
+
+
+def last_facility(record, inmate_snapshots):
+    """
+    Returns the facility that the inmate was last in for the given record. That is, the facility that
+    they are currently in if still incarcerated, or that they were released from on their final release
+    for that record.
+
+    This assumes the snapshots are provided in descending order by snapshot date, i.e. it picks the
+    facility in the first snapshot in the collection that matches the given record.
+
+    :param record: a single record
+    :param inmate_snapshots: all facility snapshots for the inmate
+    :return: the facility that the inmate last occupied for the record
+    """
+    return next((snapshot.facility for snapshot in inmate_snapshots
+                 if snapshot.key.parent().id() == record.key.id()), None)
+
+
+def was_released_only_once(record):
+    return True  # TODO See Issue #34
+
+
+# ======================================================================================= #
+# Phase 2: Transform instances of recidivism or non-recidivism into metrics for reduction #
+# ======================================================================================= #
+
 def map_recidivism_combinations(inmate, recidivism_events):
     """
     Takes in an inmate and all of her recidivism events and returns an array of "recidivism
@@ -44,7 +224,19 @@ def map_recidivism_combinations(inmate, recidivism_events):
 
     Effectively, this translates a particular recidivism event into many recidivism metrics.
     This is because each metric represents one of many possible combinations of characteristics
-    being tracked for that event.
+    being tracked for that event. For example, if an asian male is reincarcerated, there is a
+    metric that corresponds to asian people, one to males, one to asian males, one to all people,
+    and more depending on other dimensions in the data.
+
+    Example output for a hispanic female age 27 who was released in 2008 and went back to prison in 2014:
+    [
+      ({"methodology": "EVENT", "release_cohort": 2008, "follow_up_period": 5, "sex": "female", "age": "25-29"}, 0),
+      ({"methodology": "OFFENDER", "release_cohort": 2008, "follow_up_period": 5, "sex": "female", "age": "25-29"}, 0),
+      ({"methodology": "EVENT", "release_cohort": 2008, "follow_up_period": 6, "sex": "female", "age": "25-29"}, 1),
+      ({"methodology": "EVENT", "release_cohort": 2008, "follow_up_period": 6, "sex": "female", "race": "hispanic"}, 1),
+      ...
+    ]
+
     :param inmate: the inmate
     :param recidivism_events: the full set of recidivism events for the inmate
     :return: an array of key-value tuples representing specific metrics and whether they
@@ -52,29 +244,20 @@ def map_recidivism_combinations(inmate, recidivism_events):
     """
     metrics = []
     all_release_dates = release_dates(recidivism_events)
+    race = inmate.race
+    sex = inmate.sex
 
     # For each recidivism event, we need to calculate metrics across combinations of:
     # Release Cohort; Follow-up Period (up to 10 years); Methodology (Event-based, Offender-based);
     # Demographics (age, race, sex); Location (prison, region); ...
-    # TODO: Add support for conditional violations, sentence metrics, offense metrics
+    # TODO: Add support for conditional violations, offense metrics, sentence metrics - Issues 34, 33, 32
 
     for release_cohort, event in recidivism_events.iteritems():
-        recidivated = event[0]
-
-        if recidivated:
-            (recidivated, original_entry_date, release_date, release_facility,
-             reincarceration_date, reincarceration_facility, was_conditional) = event
-        else:
-            (recidivated, original_entry_date, release_date, release_facility) = event
-            reincarceration_date = None
-
-        race = inmate.race
-        sex = inmate.sex
-        entry_age = age_at_date(inmate, original_entry_date)
+        entry_age = age_at_date(inmate, event.original_entry_date)
         entry_age_bucket = age_bucket(entry_age)
 
         characteristic_combos = characteristic_combinations(
-            {"age": entry_age_bucket, "race": race, "sex": sex, "release_facility": release_facility})
+            {"age": entry_age_bucket, "race": race, "sex": sex, "release_facility": event.release_facility})
 
         # For each characteristic combination, i.e. each unique metric, look at all follow-up periods
         # to determine under which ones recidivism occurred. Map each metric (including period) to
@@ -82,28 +265,29 @@ def map_recidivism_combinations(inmate, recidivism_events):
         for combo in characteristic_combos:
             combo["release_cohort"] = release_cohort
 
-            earliest_follow_up_period = earliest_recidivated_follow_up_period(release_date, reincarceration_date)
-            relevant_periods = relevant_follow_up_periods(release_date, FOLLOW_UP_PERIODS)
+            earliest_follow_up_period = earliest_recidivated_follow_up_period(
+                event.release_date, event.reincarceration_date)
+            relevant_periods = relevant_follow_up_periods(event.release_date, FOLLOW_UP_PERIODS)
+
             for period in relevant_periods:
-                offender_based_combo = combo.copy()
-                offender_based_combo["methodology"] = "OFFENDER"
-                offender_based_combo["follow_up_period"] = period
-
-                event_based_combo = combo.copy()
-                event_based_combo["methodology"] = "EVENT"
-                event_based_combo["follow_up_period"] = period
-
-                total_releases_in_window = count_releases_in_window(release_date, period, all_release_dates)
+                offender_based_combo = augment_combination(combo, "OFFENDER", period)
+                event_based_combo = augment_combination(combo, "EVENT", period)
 
                 # If they didn't recidivate at all or not yet for this period (or they didn't recidivate
                 # until 10 years had passed), assign 0.
-                if not recidivated or not earliest_follow_up_period or period < earliest_follow_up_period:
+                if not event.recidivated or not earliest_follow_up_period or period < earliest_follow_up_period:
                     metrics.append((offender_based_combo, 0))
                     metrics.append((event_based_combo, 0))
                 else:
+                    # TODO: This may be a bug. I think the first instance should be 1/1, the second 1/2,
+                    # the third 1/3, and so forth. As written, all instances in the period would be 1/k, which
+                    # would reduce the calculated offender-based metric and seemingly cause the issue we see
+                    # where recidivism rate goes _down_ in later periods for the offender methodology.
+
                     # For offender-based recidivism, we weight each instance of recidivism as equal to 1 / k,
                     # where k = the number of releases from prison for that inmate within that window.
                     # See "Following Incarceration, Most Released Offenders Never Return to Prison" by Rhodes et. al.
+                    total_releases_in_window = count_releases_in_window(event.release_date, period, all_release_dates)
                     metrics.append((offender_based_combo, 1.0 / total_releases_in_window))
                     metrics.append((event_based_combo, 1))
 
@@ -114,10 +298,11 @@ def release_dates(recidivism_events):
     """
     Returns the array of release dates extracted from the given array of recidivism
     events. The output is the same length as the input.
+
     :param recidivism_events: the array of recidivism events
     :return: the array of release dates
     """
-    return [event[2] for _cohort, event in recidivism_events.iteritems()]
+    return [event.release_date for _cohort, event in recidivism_events.iteritems()]
 
 
 def count_releases_in_window(start_date, follow_up_period, all_release_dates):
@@ -147,6 +332,7 @@ def earliest_recidivated_follow_up_period(release_date, reincarceration_date):
     recidivism has occurred. For example, if someone was released from prison on
     March 14, 2005 and reincarcerated on April 23, 2008, then the earliest follow
     up period is 4, as they had not yet recidivated within 3 years, but had within 4.
+
     :param release_date: the date of release
     :param reincarceration_date: the date of reincarceration
     :return: the earliest follow-up period under which recidivism occurred, or None if
@@ -186,16 +372,17 @@ def relevant_follow_up_periods(release_date, follow_up_periods):
             if release_date + relativedelta(years=period - 1) <= date.today()]
 
 
-def age_at_date(inmate, date):
+def age_at_date(inmate, check_date):
     """
     Returns the age that the inmate was at the given date.
     :param inmate: the inmate
-    :param date: the date to check
+    :param check_date: the date to check
     :return: the age of the inmate at the given date, or None if no birthday is known
     """
     birthday = inmate.birthday
-    return None if birthday is None else date.year - birthday.year - ((date.month, date.day) <
-                                                                      (birthday.month, birthday.day))
+    return None if birthday is None else \
+        check_date.year - birthday.year - \
+        ((check_date.month, check_date.day) < (birthday.month, birthday.day))
 
 
 def age_bucket(age):
@@ -206,11 +393,11 @@ def age_bucket(age):
     """
     if age < 25:
         return "<25"
-    elif 25 <= age <= 29:
+    elif age <= 29:
         return "25-29"
-    elif 30 <= age <= 34:
+    elif age <= 34:
         return "30-34"
-    elif 35 <= age <= 39:
+    elif age <= 39:
         return "35-39"
     else:
         return "40<"
@@ -239,188 +426,73 @@ def characteristic_combinations(characteristics):
     return combos
 
 
-def find_recidivism(inmate, include_conditional_violations=False):
+def augment_combination(characteristic_combo, methodology, period):
     """
-    Classifies all individual sentences for the inmate as either leading to recidivism or not.
-    Transforms each sentence from which the inmate has been released into a mapping from its
-    release cohort to the details of the event. The release cohort is an integer for the year,
-    e.g. 2006. The event details are a tuple as such:
+    Creates a shallow copy of the given characteristic combination and sets the
+    given methodology and follow up period on the copy.
 
-    If they recidivated after a particular sentence:
-    (True, original entrance date, release date, facility released from, reincarceration date,
-    facility reincarcerated to, True if this was a new crime or False if a violation of
-    conditional release)
-
-    If they did not recidivate after a particular sentence:
-    (False, original entrance date, release date, facility released from)
-
-    :param inmate: an inmate to determine recidivism for
-    :param include_conditional_violations: whether or not to include violations of conditional
-    release as recidivism events
-    :return: a dictionary from release cohorts to instances of recidivism for the given inmate in
-    that cohort
+    :param characteristic_combo: the combination to copy and augment
+    :param methodology: the methodology to set, i.e. "OFFENDER" or "EVENT"
+    :param period: the followup period to set
+    :return: the augmented characteristic combination
     """
-    records = Record.query(ancestor=inmate.key).order(Record.custody_date).fetch()
-    snapshots = InmateFacilitySnapshot.query(ancestor=inmate.key).order(-InmateFacilitySnapshot.snapshot_date).fetch()
-
-    recidivism_events = {}
-
-    for index, record in enumerate(records):
-        record_id = record.key.id()
-
-        original_entry_date = first_entrance(record)
-
-        if original_entry_date is None:
-            # If there is no entry date on the record, there is nothing we can process. Skip it.
-            # See Issue #49.
-            continue
-
-        if record.is_released and not record.last_release_date:
-            # If the record is marked as released but there is no release date, there is nothing we
-            # can process. Skip it. See Issue #51.
-            continue
-
-        release_date = final_release(record)
-        release_cohort = release_date.year if release_date else None
-        release_facility = last_facility(record, snapshots)
-
-        # If this is their last (or only) record, then they did not recidivate for this one!
-        if len(records) - index == 1:
-            # There is only something to calculate if they are out of prison from this last record
-            if record.is_released:
-                logging.debug("Inmate was released from last or only record %s. No recidivism." %
-                              record_id)
-                recidivism_events[release_cohort] = (False, original_entry_date, release_date, release_facility)
-            else:
-                logging.debug("Inmate is still incarcerated for last or only record %s. Nothing to track" %
-                              record_id)
-
-        else:
-            # If there is a record after this one and they have been released, then they
-            # recidivated. Capture the details.
-            if record.is_released:
-                logging.debug("Inmate was released from record %s and went back again. Yes recidivism." %
-                              record_id)
-
-                later_records = records[index+1:]
-
-                recidivism_record = later_records[0]
-                reincarceration_date = first_entrance(recidivism_record)
-                reincarceration_facility = first_facility(recidivism_record, snapshots)
-
-                # If the release from the original sentence was final, i.e. was an unconditional
-                # release or a conditional release which was never revoked, then this is a
-                # relatively simple case of being released from prison and returning for a new
-                # crime: recidivism.
-                sole_release = was_released_only_once(record)
-
-                # However, if the release was conditional and it was revoked, e.g. a parole violation,
-                # prior to the final release then we want to capture that intermediate "recidivism"
-                # event for specific metrics.
-                if include_conditional_violations and not sole_release:
-                    intermediate_release_date = None  # TODO
-                    intermediate_release_cohort = intermediate_release_date.year
-                    re_entrance = subsequent_entrance(record)
-
-                    intermediate_event = (True, original_entry_date, intermediate_release_date, release_facility,
-                                          re_entrance, release_facility, False)
-                    recidivism_events[intermediate_release_cohort] = intermediate_event
-
-                event = (True, original_entry_date, release_date, release_facility,
-                         reincarceration_date, reincarceration_facility, True)
-                recidivism_events[release_cohort] = event
-
-    return recidivism_events
+    augmented_combo = characteristic_combo.copy()
+    augmented_combo["methodology"] = methodology
+    augmented_combo["follow_up_period"] = period
+    return augmented_combo
 
 
-def first_entrance(record):
+class RecidivismEvent(object):
     """
-    The first entrance is when an inmate first when to prison for a new sentence. An inmate may
-    be conditionally released and returned to prison on violation of conditions for the same
-    sentence, yielding a subsequent entrance date.
-    :param record: a single record
-    :return: when the inmate first entered into prison for this record
+    Models details related to a recidivism or non-recidivism event, that is, the information
+    pertaining to a release from prison, whether or not a reincarceration later took place.
+    This includes all of the information that we will want to track when calculating metrics
+    pertaining to recidivism.
     """
-    return record.custody_date
 
+    def __init__(self,
+                 recidivated,
+                 original_entry_date,
+                 release_date,
+                 release_facility,
+                 reincarceration_date=None,
+                 reincarceration_facility=None,
+                 was_conditional=False):
 
-def subsequent_entrance(record):
-    """
-    A subsequent entrance is when an inmate returns to prison for a given sentence, after having
-    already been conditionally for that same sentence. It is not returning to prison for a brand
-    new sentence.
-    :param record: a single record
-    :return: when the inmate re-entered prison for this record
-    """
-    return record.last_custody_date
+        self.recidivated = recidivated
+        self.original_entry_date = original_entry_date
+        self.release_date = release_date
+        self.release_facility = release_facility
+        self.reincarceration_date = reincarceration_date
+        self.reincarceration_facility = reincarceration_facility
+        self.was_conditional = was_conditional
 
+    @staticmethod
+    def recidivism_event(original_entry_date, release_date, release_facility, reincarceration_date,
+                         reincarceration_facility, was_conditional):
+        """
+        Creates a RecidivismEvent instance for an event where reincarceration occurred.
 
-def final_release(record):
-    """
-    The release cohort is the year in which an inmate was released from prison for a particular
-    sentence. This is used to normalize recidivism calculation, e.g. calculating and comparing
-    recidivism for all inmates released in a particular calendar year.
-    :param record: a single record
-    :return: None if the inmate is still in custody, otherwise the final release of this record,
-    from which release cohort can be derived
-    """
-    if not record.is_released:
-        return None
+        :param original_entry_date: the date of original entry into prison
+        :param release_date: the date of release from prison
+        :param release_facility: the facility released from
+        :param reincarceration_date: the date of reincarceration (recidivism)
+        :param reincarceration_facility: the facility returned to upon reincarceration
+        :param was_conditional: whether or not this reincarceration was due to some violation
+        of release conditions, e.g. a revocation of parole
+        :return: a RecidivismEvent for an instance of reincarceration
+        """
+        return RecidivismEvent(True, original_entry_date, release_date, release_facility, reincarceration_date,
+                               reincarceration_facility, was_conditional)
 
-    return record.last_release_date
+    @staticmethod
+    def non_recidivism_event(original_entry_date, release_date, release_facility):
+        """
+        Creates a RecidivismEvent instance for an event where reincarceration did not occur.
 
-
-def first_facility(record, inmate_snapshots):
-    """
-    Returns the facility that the inmate was first in for the given record. That is, the facility that
-    they started that record in, whether or not they have since been released.
-
-    This assumes the snapshots are provided in descending order by snapshot date, i.e. it picks the
-    facility in the last snapshot in the collection that matches the given record.
-    :param record: a single record
-    :param inmate_snapshots: all facility snapshots for the inmate
-    :return: the facility that the inmate first occupied for the record
-    """
-    return last_facility(record, reversed(inmate_snapshots))
-
-
-def last_facility(record, inmate_snapshots):
-    """
-    Returns the facility that the inmate was last in for the given record. That is, the facility that
-    they are currently in if still incarcerated, or that they were released from on their final release
-    for that record.
-
-    This assumes the snapshots are provided in descending order by snapshot date, i.e. it picks the
-    facility in the first snapshot in the collection that matches the given record.
-    :param record: a single record
-    :param inmate_snapshots: all facility snapshots for the inmate
-    :return: the facility that the inmate last occupied for the record
-    """
-    return next((snapshot.facility for snapshot in inmate_snapshots
-                 if snapshot.key.parent().id() == record.key.id()), None)
-
-
-def was_released_only_once(record):
-    return True  # TODO
-
-
-def was_released_multiple_times(record):
-    return True  # TODO
-
-
-def was_unconditionally_released(record):  # TODO
-    """
-    An inmate was unconditionally released if there is only an original custody date or it matches
-    the last custody date perfectly.
-    :param record:
-    :return:
-    """
-    return record.cond_release_date is None or record.custody_date == record.last_custody_date
-
-
-def was_conditionally_released(record):  # TODO
-    return None
-
-
-def was_conditionally_released_but_returned(record):  # TODO
-    return None
+        :param original_entry_date: the date of original entry into prison
+        :param release_date: the date of release from prison
+        :param release_facility: the facility released from
+        :return: a RecidivismEvent for an instance of non-reincarceration
+        """
+        return RecidivismEvent(False, original_entry_date, release_date, release_facility)


### PR DESCRIPTION
This cleans up the calculator code a bit. In three fixup commits that I'll squash before merging:
1. 99% of the cleanup: adds some type safety and extracts some code
2. Reorganizes code in `calculator.py` by shifting two blocks into logical order
3. A couple of doc improvements