### PR TITLE
[WIP]: Conditional release recidivism, i.e. revocations

### DIFF
--- a/calculator/recidivism/calculator.py
+++ b/calculator/recidivism/calculator.py
@@ -92,21 +92,22 @@ def map_recidivism_combinations(inmate, recidivism_events):
     metrics = []
     all_reincarceration_dates = reincarceration_dates(recidivism_events)
 
-    for release_cohort, event in recidivism_events.iteritems():
-        characteristic_combos = characteristic_combinations(inmate, event)
+    for release_cohort, events in recidivism_events.iteritems():
+        for event in events:
+            characteristic_combos = characteristic_combinations(inmate, event)
 
-        earliest_recidivism_period = earliest_recidivated_follow_up_period(
-            event.release_date, event.reincarceration_date)
+            earliest_recidivism_period = earliest_recidivated_follow_up_period(
+                event.release_date, event.reincarceration_date)
 
-        relevant_periods = relevant_follow_up_periods(
-            event.release_date, date.today(), FOLLOW_UP_PERIODS)
+            relevant_periods = relevant_follow_up_periods(
+                event.release_date, date.today(), FOLLOW_UP_PERIODS)
 
-        for combo in characteristic_combos:
-            combo["release_cohort"] = release_cohort
+            for combo in characteristic_combos:
+                combo["release_cohort"] = release_cohort
 
-            metrics.extend(combination_metrics(
-                combo, event, all_reincarceration_dates,
-                earliest_recidivism_period, relevant_periods))
+                metrics.extend(combination_metrics(
+                    combo, event, all_reincarceration_dates,
+                    earliest_recidivism_period, relevant_periods))
 
     return metrics
 
@@ -126,9 +127,11 @@ def reincarceration_dates(recidivism_events):
         A list of reincarceration dates, in the order in which they appear in
         the given list of objects.
     """
-    return [event.reincarceration_date
-            for _cohort, event in recidivism_events.iteritems()
-            if event.reincarceration_date]
+    dates = []
+    for _cohort, events in recidivism_events.iteritems():
+        dates.extend([event.reincarceration_date for event in events
+                      if event.reincarceration_date])
+    return dates
 
 
 def count_reincarcerations_in_window(start_date,

--- a/calculator/recidivism/recidivism_event.py
+++ b/calculator/recidivism/recidivism_event.py
@@ -89,7 +89,7 @@ class RecidivismEvent(object):
 
     @staticmethod
     def non_recidivism_event(original_entry_date, release_date,
-                             release_facility):
+                             release_facility, was_conditional=False):
         """Creates a RecidivismEvent instance for an event where reincarceration
         did not occur.
 
@@ -100,12 +100,16 @@ class RecidivismEvent(object):
                 prison for this record.
             release_facility: The facility that the inmate was last released
                 from for this record.
+            was_conditional: A boolean indicating whether or not the recidivism,
+                if it occurred, was due to a conditional violation, as opposed
+                to a new incarceration.
 
         Returns:
             A RecidivismEvent for an instance where recidivism did not occur.
         """
         return RecidivismEvent(False, original_entry_date, release_date,
-                               release_facility)
+                               release_facility,
+                               was_conditional=was_conditional)
 
     def __repr__(self):
         return "<RecidivismEvent recidivated: %s, original_entry_date: %s, " \

--- a/tests/calculator/recidivism/identifier_test.py
+++ b/tests/calculator/recidivism/identifier_test.py
@@ -195,23 +195,23 @@ class TestFindRecidivism(object):
 
         assert len(recidivism_events_by_cohort) == 2
 
-        assert recidivism_events_by_cohort[2010] == recidivism_event.\
-            RecidivismEvent.recidivism_event(
+        assert recidivism_events_by_cohort[2010] == [
+            recidivism_event.RecidivismEvent.recidivism_event(
                 initial_incarceration.custody_date,
                 initial_incarceration.latest_release_date,
                 initial_incarceration_second_snapshot.latest_facility,
                 first_reincarceration.custody_date,
                 first_reincarceration_first_snapshot.latest_facility,
-                False)
+                False)]
 
-        assert recidivism_events_by_cohort[2014] == recidivism_event.\
-            RecidivismEvent.recidivism_event(
+        assert recidivism_events_by_cohort[2014] == [
+            recidivism_event.RecidivismEvent.recidivism_event(
                 first_reincarceration.custody_date,
                 first_reincarceration.latest_release_date,
                 first_reincarceration_second_snapshot.latest_facility,
                 subsequent_reincarceration.custody_date,
                 subsequent_reincarceration_snapshot.latest_facility,
-                False)
+                False)]
 
     def test_find_recidivism_no_records_at_all(self):
         """Tests the find_recidivism function when the inmate has no records."""
@@ -238,11 +238,11 @@ class TestFindRecidivism(object):
 
         assert len(recidivism_events_by_cohort) == 1
 
-        assert recidivism_events_by_cohort[2010] == recidivism_event.\
-            RecidivismEvent.non_recidivism_event(
+        assert recidivism_events_by_cohort[2010] == [
+            recidivism_event.RecidivismEvent.non_recidivism_event(
                 initial_incarceration.custody_date,
                 initial_incarceration.latest_release_date,
-                initial_incarceration_second_snapshot.latest_facility)
+                initial_incarceration_second_snapshot.latest_facility)]
 
     def test_find_recidivism_still_incarcerated_on_first(self):
         """Tests the find_recidivism function where the inmate is still
@@ -286,14 +286,14 @@ class TestFindRecidivism(object):
         # because of its lack of a custody date.
         assert len(recidivism_events_by_cohort) == 1
 
-        assert recidivism_events_by_cohort[2014] == recidivism_event.\
-            RecidivismEvent.recidivism_event(
+        assert recidivism_events_by_cohort[2014] == [
+            recidivism_event.RecidivismEvent.recidivism_event(
                 first_reincarceration.custody_date,
                 first_reincarceration.latest_release_date,
                 first_reincarceration_second_snapshot.latest_facility,
                 subsequent_reincarceration.custody_date,
                 subsequent_reincarceration_snapshot.latest_facility,
-                False)
+                False)]
 
     def test_find_recidivism_invalid_released_but_no_release_date(self):
         """Tests the find_recidivism function error handling when the record
@@ -324,14 +324,14 @@ class TestFindRecidivism(object):
         # because of its lack of a release date although released=True.
         assert len(recidivism_events_by_cohort) == 1
 
-        assert recidivism_events_by_cohort[2014] == recidivism_event.\
-            RecidivismEvent.recidivism_event(
+        assert recidivism_events_by_cohort[2014] == [
+            recidivism_event.RecidivismEvent.recidivism_event(
                 first_reincarceration.custody_date,
                 first_reincarceration.latest_release_date,
                 first_reincarceration_second_snapshot.latest_facility,
                 subsequent_reincarceration.custody_date,
                 subsequent_reincarceration_snapshot.latest_facility,
-                False)
+                False)]
 
     def test_find_recidivism_invalid_released_but_no_entry_date_on_reincarceration(self):  # pylint: disable=line-too-long
         """Tests the find_recidivism function error handling when the record
@@ -365,14 +365,14 @@ class TestFindRecidivism(object):
         # record-keeping error gets sorted to the front by our Datastore query.
         assert len(recidivism_events_by_cohort) == 1
 
-        assert recidivism_events_by_cohort[2010] == recidivism_event.\
-            RecidivismEvent.recidivism_event(
+        assert recidivism_events_by_cohort[2010] == [
+            recidivism_event.RecidivismEvent.recidivism_event(
                 initial_incarceration.custody_date,
                 initial_incarceration.latest_release_date,
                 initial_incarceration_second_snapshot.latest_facility,
                 subsequent_reincarceration.custody_date,
                 subsequent_reincarceration_snapshot.latest_facility,
-                False)
+                False)]
 
 
 def record(parent_key, is_released, custody_date, latest_release_date=None):


### PR DESCRIPTION
This is a first pass at support for detecting and calculating recidivism from conditional releases, i.e. revocation. The implementation relies on iterating over snapshots that we have for the individual, looking at changes in custody dates, release dates, and facilities to detect if there was a conditional release and/or a return following a conditional release. 

This is still a Work In Progress because I need to add new, thorough test coverage for revocation detection. My implementation tries to be defensive against manual data issues and things like consecutive snapshots changing the same date, which is a partial complexity source and will require ample testing. There is a test coverage decrease coming until that is complete.

The first commit enhances the existing calculation code to support multiple recidivism events for a person in a single release cohort (calendar year). This was incredibly unlikely and maybe non-existent within the NY source data, but will happen, albeit infrequently, once we start tracking revocation.

The second commit adds the core logic for revocation detection. It's fairly complicated and I'm not stoked about it, but I don't think we have a markedly better path at the moment. Please tear this apart! Would love to see that I've over-thought this, and would welcome with less enthusiasm being told that I've under-thought this.