### PR TITLE
Updates region manifest

### DIFF
--- a/ingest/queue_control.py
+++ b/ingest/queue_control.py
@@ -82,7 +82,7 @@ class ScraperStart(webapp2.RequestHandler):
                     logging.info("Starting new %s scrape(s) for %s."
                                  % (scrape_type, region))
 
-                    scraper = regions.get_scraper(region)
+                    scraper = regions.get_scraper_from_cache(region)
 
                     # Set up scraper for new session
                     scraper.setup(scrape_type)
@@ -151,7 +151,7 @@ class ScraperStop(webapp2.RequestHandler):
                 logging.info("Stopping %s scrapes for %s."
                              % (scrape_types, region))
 
-                scraper = regions.get_scraper(region)
+                scraper = regions.get_scraper_from_cache(region)
                 scraper.stop_scrape(scrape_types)
 
         else:
@@ -193,7 +193,7 @@ class ScraperResume(webapp2.RequestHandler):
                     logging.info("Resuming %s scrape for %s."
                                  % (scrape_type, region))
 
-                    scraper = regions.get_scraper(region)
+                    scraper = regions.get_scraper_from_cache(region)
                     scraper.setup(scrape_type)
                     scraper.resume_scrape(scrape_type)
 

--- a/ingest/us_ny/us_ny_scraper.py
+++ b/ingest/us_ny/us_ny_scraper.py
@@ -143,7 +143,7 @@ def start_scrape(scrape_type):
     serial_params = json.dumps(params)
 
     taskqueue.add(url=SCRAPER_WORK_URL,
-                  queue_name=REGION.scrape_queue_name,
+                  queue_name=REGION.queues[0],
                   params={'region': REGION.region_code,
                           'task': "scrape_search_page",
                           'params': serial_params})
@@ -215,7 +215,7 @@ def stop_scrape(scrape_types):
             "type: %s." % str(scrape))
         deferred.defer(resume_scrape, scrape, _countdown=60)
 
-    q = taskqueue.Queue(REGION.scrape_queue_name)
+    q = taskqueue.Queue(REGION.queues[0])
     q.purge()
 
 
@@ -275,7 +275,7 @@ def resume_scrape(scrape_type):
     serial_params = json.dumps(params)
 
     taskqueue.add(url=SCRAPER_WORK_URL,
-                  queue_name=REGION.scrape_queue_name,
+                  queue_name=REGION.queues[0],
                   params={'region': REGION.region_code,
                           'task': "scrape_search_page",
                           'params': serial_params})
@@ -366,7 +366,7 @@ def scrape_search_page(params):
         task_name = "scrape_inmate"
 
     taskqueue.add(url=SCRAPER_WORK_URL,
-                  queue_name=REGION.scrape_queue_name,
+                  queue_name=REGION.queues[0],
                   params={'region': REGION.region_code,
                           'task': task_name,
                           'params': search_results_params_serial})
@@ -526,7 +526,7 @@ def scrape_search_results_page(params):
         result_params = json.dumps(result_params)
 
         taskqueue.add(url=SCRAPER_WORK_URL,
-                      queue_name=REGION.scrape_queue_name,
+                      queue_name=REGION.queues[0],
                       params={'region': REGION.region_code,
                               'task': "scrape_inmate",
                               'params': result_params})
@@ -589,7 +589,7 @@ def scrape_search_results_page(params):
     next_params = json.dumps(next_params)
 
     taskqueue.add(url=SCRAPER_WORK_URL,
-                  queue_name=REGION.scrape_queue_name,
+                  queue_name=REGION.queues[0],
                   params={'region': REGION.region_code,
                           'task': "scrape_search_results_page",
                           'params': next_params})
@@ -968,7 +968,7 @@ def scrape_disambiguation(page_tree, query_content, scrape_type, ignore_list):
             task_params = json.dumps(task_params)
 
             taskqueue.add(url=SCRAPER_WORK_URL,
-                          queue_name=REGION.scrape_queue_name,
+                          queue_name=REGION.queues[0],
                           params={'region': REGION.region_code,
                                   'task': "scrape_inmate",
                                   'params': task_params})

--- a/ingest/worker.py
+++ b/ingest/worker.py
@@ -20,6 +20,7 @@
 
 import logging
 import webapp2
+from google.appengine.api import memcache
 from requests.packages.urllib3.contrib.appengine import TimeoutError
 from utils import regions
 from utils.auth import authenticate_request
@@ -80,7 +81,7 @@ class Scraper(webapp2.RequestHandler):
         logging.info("Queue %s, processing task (%s) for %s." %
                      (queue_name, task, region))
 
-        scraper = regions.get_scraper(region)
+        scraper = regions.get_scraper_from_cache(region)
         scraper_task = getattr(scraper, task)
 
         try:

--- a/region_manifest.yaml
+++ b/region_manifest.yaml
@@ -19,14 +19,17 @@
 regions:
 
   us_ny:
-    region_name: New York State
-    agency_name: Department of Corrections and Community Supervision (DOCCS)
-    region_code: us_ny
+    agency_name: Department of Corrections and Community Supervision
     agency_type: prison
-    scrape_queue_name: us-ny-scraper
     base_url: http://nysdoccslookup.doccs.ny.gov
-    names_file: us_ny_names.csv
     entity_kinds:
       inmate: UsNyInmate
       record: UsNyRecord
       snapshot: UsNySnapshot
+    names_file: us_ny_names.csv
+    queues:
+    - us-ny-scraper
+    region_code: us_ny
+    region_name: New York State
+    scraper_package: us_ny
+    timezone: America/New_York

--- a/tests/utils/regions_test.py
+++ b/tests/utils/regions_test.py
@@ -23,6 +23,9 @@
 import pytest
 
 from ..context import utils
+from google.appengine.api import memcache
+from google.appengine.ext import ndb
+from google.appengine.ext import testbed
 from mock import patch, mock_open
 from utils import regions
 
@@ -30,61 +33,74 @@ from utils import regions
 MANIFEST_CONTENTS = """
     regions:
       us_ny:
-        region_name: New York State
-        agency_name: Department of Corrections and Community Supervision (DOCCS)
-        region_code: us_ny
+        agency_name: Department of Corrections and Community Supervision
         agency_type: prison
-        scrape_queue_name: us-ny-scraper
         base_url: http://nysdoccslookup.doccs.ny.gov
-        names_file: us_ny_names.csv
         entity_kinds:
           inmate: UsNyInmate
           record: UsNyRecord
           snapshot: UsNySnapshot
+        names_file: us_ny_names.csv
+        queues:
+        - us-ny-scraper
+        region_code: us_ny
+        region_name: New York State
+        scraper_package: us_ny
+        timezone: America/New_York
       us_fl:
-        region_name: Florida State
         agency_name: Department of Corrections
-        region_code: us_fl
         agency_type: prison
-        scrape_queue_name: us-fl-scraper
         base_url: http://www.dc.state.fl.us/OffenderSearch/Search.aspx
-        names_file: us_fl_names.csv
         entity_kinds:
           inmate: UsFlInmate
           record: UsFlRecord
           snapshot: UsFlSnapshot
+        names_file: us_fl_names.csv
+        queues:
+        - us-fl-scraper
+        - a-different-queue
+        region_code: us_fl
+        region_name: Florida State
+        scraper_class: a_different_scraper
+        scraper_package: us_fl
+        timezone: America/New_York
     """
 
 FULL_MANIFEST = {
     'regions': {
         'us_ny': {
-            'region_name': 'New York State',
             'agency_name': 'Department of Corrections and '
-                           'Community Supervision (DOCCS)',
-            'region_code': 'us_ny',
+                           'Community Supervision',
             'agency_type': 'prison',
-            'scrape_queue_name': 'us-ny-scraper',
             'base_url': 'http://nysdoccslookup.doccs.ny.gov',
-            'names_file': 'us_ny_names.csv',
             'entity_kinds': {
                 'inmate': 'UsNyInmate',
                 'record': 'UsNyRecord',
                 'snapshot': 'UsNySnapshot'
-            }
+            },
+            'names_file': 'us_ny_names.csv',
+            'queues': ['us-ny-scraper'],
+            'region_code': 'us_ny',
+            'region_name': 'New York State',
+            'scraper_package': 'us_ny',
+            'timezone': 'America/New_York'
         },
         'us_fl': {
-            'region_name': 'Florida State',
             'agency_name': 'Department of Corrections',
-            'region_code': 'us_fl',
             'agency_type': 'prison',
-            'scrape_queue_name': 'us-fl-scraper',
             'base_url': 'http://www.dc.state.fl.us/OffenderSearch/Search.aspx',
-            'names_file': 'us_fl_names.csv',
             'entity_kinds': {
                 'inmate': 'UsFlInmate',
                 'record': 'UsFlRecord',
                 'snapshot': 'UsFlSnapshot'
-            }
+            },
+            'names_file': 'us_fl_names.csv',
+            'queues': ['us-fl-scraper', 'a-different-queue'],
+            'region_code': 'us_fl',
+            'region_name': 'Florida State',
+            'scraper_class': 'a_different_scraper',
+            'scraper_package': 'us_fl',
+            'timezone': 'America/New_York'
         }
     }
 }
@@ -147,7 +163,7 @@ def test_get_scraper_module():
 
 
 def test_get_scraper():
-    scraper = regions.get_scraper('us_ny')
+    scraper = regions.get_scraper('us_ny', 'us_ny_scraper')
     assert scraper.__name__ == 'ingest.us_ny.us_ny_scraper'
 
 
@@ -159,6 +175,12 @@ def test_region_class():
     assert region.get_snapshot_kind().__name__ == 'UsNySnapshot'
 
 
+def test_region_class_with_scraper_class_and_multiple_queues():
+    region = with_manifest(regions.Region, 'us_fl')
+    assert region.scraper_class == 'a_different_scraper'
+    assert region.queues == ['us-fl-scraper', 'a-different-queue']
+
+
 def with_manifest(func, *args, **kwargs):
     with patch("__builtin__.open",
                mock_open(read_data=MANIFEST_CONTENTS)) \
@@ -166,3 +188,24 @@ def with_manifest(func, *args, **kwargs):
         value = func(*args, **kwargs)
         mock_file.assert_called_with('region_manifest.yaml', 'r')
         return value
+
+
+class TestRegionsCache(object):
+    """Tests for caching methods in the module."""
+
+    def setup_method(self, _test_method):
+        # noinspection PyAttributeOutsideInit
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_memcache_stub()
+        ndb.get_context().clear_cache()
+
+    def teardown_method(self, _test_method):
+        self.testbed.deactivate()
+
+    def test_get_scraper_from_cache(self):
+        scraper = regions.get_scraper_from_cache('us_ny')
+        assert scraper.__name__ == 'ingest.us_ny.us_ny_scraper'
+
+        assert memcache.get('us_ny_scraper_package') == 'us_ny'
+        assert memcache.get('us_ny_scraper_class') == 'us_ny_scraper'

--- a/tests/utils/regions_test.py
+++ b/tests/utils/regions_test.py
@@ -56,6 +56,9 @@ MANIFEST_CONTENTS = """
           record: UsFlRecord
           snapshot: UsFlSnapshot
         names_file: us_fl_names.csv
+        params:
+          foo: bar
+          sha: baz
         queues:
         - us-fl-scraper
         - a-different-queue
@@ -95,6 +98,10 @@ FULL_MANIFEST = {
                 'snapshot': 'UsFlSnapshot'
             },
             'names_file': 'us_fl_names.csv',
+            'params': {
+                'foo': 'bar',
+                'sha': 'baz'
+            },
             'queues': ['us-fl-scraper', 'a-different-queue'],
             'region_code': 'us_fl',
             'region_name': 'Florida State',
@@ -173,12 +180,16 @@ def test_region_class():
     assert region.get_inmate_kind().__name__ == 'UsNyInmate'
     assert region.get_record_kind().__name__ == 'UsNyRecord'
     assert region.get_snapshot_kind().__name__ == 'UsNySnapshot'
+    assert not region.params
+    assert region.queues == ['us-ny-scraper']
+    assert region.scraper_class == 'us_ny_scraper'
 
 
 def test_region_class_with_scraper_class_and_multiple_queues():
     region = with_manifest(regions.Region, 'us_fl')
-    assert region.scraper_class == 'a_different_scraper'
+    assert region.params == {'foo': 'bar', 'sha': 'baz'}
     assert region.queues == ['us-fl-scraper', 'a-different-queue']
+    assert region.scraper_class == 'a_different_scraper'
 
 
 def with_manifest(func, *args, **kwargs):

--- a/utils/regions.py
+++ b/utils/regions.py
@@ -22,7 +22,9 @@ criminal justice data and calculate metrics.
 """
 
 
+import logging
 import yaml
+from google.appengine.api import memcache
 
 
 class Region(object):
@@ -32,46 +34,55 @@ class Region(object):
     and has helper functions to get region-specific configuration info.
 
     Attributes:
-        region_code: (string) Region code
-        region_name: (string) Human-readable region name
         agency_name: (string) Human-readable agency name
         agency_type: (string) 'prison' or 'jail'
-        scrape_queue_name: (string) Queue name for scraping queue
         base_url: (string) Base URL for scraping
-        names_file: (string) Filename of names file for this region
         entity_kinds: (dict) Mapping of top-level entity kind names (inmate,
             record, snapshot) to region subclasses. E.g.,
             {'inmate': 'UsNyInmate',
              'record': 'UsNyRecord',
              'snapshot': 'UsNySnapshot'}
-
+        names_file: (string) Filename of names file for this region
+        queues: (list) List of queue name for acceptable scraping queues
+        region_code: (string) Region code
+        region_name: (string) Human-readable region name
+        scraper_class: (string) Name of the class for this region's scraper.
+            If absent, this assumes the scraper is `[region_code]_scraper`.
+        scraper_package: (string) Name of the package with this region's scraper
+        timezone: (string) Timezone in which this region resides. If the region
+            is in multiple timezones, this is the timezone in which most of the
+            region resides, where "most" is whatever is most useful for that
+            region, e.g. population count versus land size.
     """
 
     def __init__(self, region_code):
         # Attempt to load region info from region_manifest
         region_config = load_region_manifest(region_code)
 
-        self.region_code = region_config["region_code"]
-        self.region_name = region_config["region_name"]
         self.agency_name = region_config["agency_name"]
         self.agency_type = region_config["agency_type"]
-        self.scrape_queue_name = region_config["scrape_queue_name"]
         self.base_url = region_config["base_url"]
-
-        self.names_file = get_name_list_file(self.region_code)
-
         self.entity_kinds = region_config["entity_kinds"]
+        self.region_code = region_config["region_code"]
+        self.names_file = get_name_list_file(self.region_code)
+        self.queues = region_config["queues"]
+        self.region_name = region_config["region_name"]
+        self.scraper_class = region_config.get("scraper_class",
+                                               self.region_code + "_scraper")
+        self.scraper_package = region_config["scraper_package"]
+        self.timezone = region_config["timezone"]
 
     def scraper(self):
-        """Return the scraper class for this region
+        """Return the scraper module for this region
 
         Args:
             N/A
 
         Returns:
-            Top-level scraper module for this region
+            Region's fully resolved scraper class
+            (e.g., ingest.us_ny.us_ny_scraper)
         """
-        return get_scraper(self.region_code)
+        return get_scraper(self.scraper_package, self.scraper_class)
 
     def get_inmate_kind(self):
         """Return the Inmate PolyModel sub-kind for this region
@@ -115,7 +126,7 @@ def get_subkind(region_code, parent_kind_name):
         parent_kind_name: (string) Name of the top-level PolyModel kind
 
     Returns:
-        Model subclass (e.g., scraper.us_ny.us_ny_record.UsNyRecord)
+        Model subclass (e.g., ingest.us_ny.us_ny_record.UsNyRecord)
     """
     parent_kind_name = parent_kind_name.lower()
 
@@ -132,38 +143,85 @@ def get_subkind(region_code, parent_kind_name):
     return subkind
 
 
-def get_scraper_module(region_code):
+def get_scraper_module(scraper_package):
     """Retrieve top-level module for the given region
 
     Retrieves the scraper module for a particular region. Note that this is
-    only the module containing the scraper and entity subclasses/models, not
+    only the module containing the scraper and/or entity subclasses/models, not
     the scraper itself (use get_scraper() to get the scraper).
 
+    Some regions will use a general-purpose scraper that is not in the same
+    package as the entity sub-kinds for that region. For such a region, you
+    would pass different args into this method to get the scraper class versus
+    the entity classes.
+
     Args:
-        region_code: (string) Region code to get scraper for
+        scraper_package: (string) The package where the scraper resides
 
     Returns:
-        Scraper module (e.g., scraper.us_ny)
+        Scraper module (e.g., ingest.us_ny)
     """
     top_level = __import__("ingest")
-    module = getattr(top_level, region_code)
+    module = getattr(top_level, scraper_package)
 
     return module
 
 
-def get_scraper(region_code):
+def get_scraper(scraper_package, scraper_class):
     """Retrieve the scraper for a particular region
+
+    Args:
+        scraper_package: (string) Name of the region's scraper package
+        scraper_class: (string) Name of the scraper class itself
+
+    Returns:
+        Region's fully resolved scraper class (e.g., ingest.us_ny.us_ny_scraper)
+    """
+    scraper_module = get_scraper_module(scraper_package)
+    scraper = getattr(scraper_module, scraper_class)
+
+    return scraper
+
+
+def get_scraper_from_cache(region_code):
+    """Retrieves the scraper for a particular region
+
+    Since this is called to retrieve the scraper class for every new instance of
+    a scraper class at runtime, we cache the value in Memcache and retrieve it
+    from there if available. If not available, we parse the region manifest and
+    cache it.
 
     Args:
         region_code: (string) Region code to get scraper for
 
     Returns:
-        Region's scraper module (e.g., scraper.us_ny.us_ny_scraper)
+        Region's scraper module (e.g., ingest.us_ny.us_ny_scraper)
     """
-    scraper_module = get_scraper_module(region_code)
-    scraper = getattr(scraper_module, region_code + "_scraper")
+    logging.debug('Fetching scraper package and class from cache '
+                  'for region %s', region_code)
 
-    return scraper
+    memcache_package_name = region_code + "_scraper_package"
+    scraper_package = memcache.get(memcache_package_name)
+
+    memcache_class_name = region_code + "_scraper_class"
+    scraper_class = memcache.get(memcache_class_name)
+
+    if not scraper_package and not scraper_class:
+        logging.debug('Scraper package and class not in cache cache, loading '
+                      'from manifest for region %s', region_code)
+
+        region = Region(region_code)
+        scraper_package = region.scraper_package
+        memcache.set(key=memcache_package_name,
+                     value=scraper_package,
+                     time=3600)
+
+        scraper_class = region.scraper_class
+        memcache.set(key=memcache_class_name,
+                     value=region.scraper_class,
+                     time=3600)
+
+    return get_scraper(scraper_package, scraper_class)
 
 
 def get_supported_regions(full_manifest=False):

--- a/utils/regions.py
+++ b/utils/regions.py
@@ -43,11 +43,12 @@ class Region(object):
              'record': 'UsNyRecord',
              'snapshot': 'UsNySnapshot'}
         names_file: (string) Filename of names file for this region
+        params: (dict) Optional mapping of key-value pairs specific to region
         queues: (list) List of queue name for acceptable scraping queues
         region_code: (string) Region code
         region_name: (string) Human-readable region name
-        scraper_class: (string) Name of the class for this region's scraper.
-            If absent, this assumes the scraper is `[region_code]_scraper`.
+        scraper_class: (string) Optional name of the class for this region's
+            scraper. If absent, assumes the scraper is `[region_code]_scraper`.
         scraper_package: (string) Name of the package with this region's scraper
         timezone: (string) Timezone in which this region resides. If the region
             is in multiple timezones, this is the timezone in which most of the
@@ -65,6 +66,7 @@ class Region(object):
         self.entity_kinds = region_config["entity_kinds"]
         self.region_code = region_config["region_code"]
         self.names_file = get_name_list_file(self.region_code)
+        self.params = region_config.get("params", {})
         self.queues = region_config["queues"]
         self.region_name = region_config["region_name"]
         self.scraper_class = region_config.get("scraper_class",


### PR DESCRIPTION
This PR is ready to go, but it is branched off of the `rename-scraper-ingest` branch until that is merged. Once that is merged, I'll reissue this against master.

This does a few things:
* Adds a few new typed fields: `timezone`, `scraper_package`, and `scraper_class`
* Changes `scraper_queue_name` to an array called `queues` to permit regions that can be run on multiple queues, e.g. throttled queues
* Refactors the dynamic scraper loading methods in `regions.py` to make use of the new `scraper_*` fields, which will be necessary when we have regions for jails which use region-agnostic vendor scraping code
* Adds support for dynamic key-value pairs for regions that need them (@ohinds-vera: check out the second commit specifically and let me know if that would suit your use case)