### PR TITLE
Add a scraper for Vermont to ingest (#115)

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -26,3 +26,21 @@ cron:
   url: /calculator_pipeline?region=us_ny
   schedule: every saturday 12:00
   timezone: America/New_York
+
+- description: Start VT background scraper every day at 9pm
+  url: /scraper/start?region=us_vt&scrape_type=background
+  schedule: every day 21:00
+  timezone: America/New_York
+  retry_parameters:
+    min_backoff_seconds: 2.5
+    max_doublings: 5
+    job_age_limit: 9h
+
+- description: Stop VT scraper every day at 9am
+  url: /scraper/stop?region=us_vt&scrape_type=background
+  schedule: every day 09:00
+  timezone: America/New_York
+  retry_parameters:
+    min_backoff_seconds: 2.5
+    max_doublings: 5
+    job_age_limit: 9h

--- a/queue.yaml
+++ b/queue.yaml
@@ -14,6 +14,17 @@ queue:
     max_backoff_seconds: 300
     task_age_limit: 3d
 
+# us-vt-scraper - Vermont
+- name: us-vt-scraper
+  mode: push
+  rate: 5/m
+  bucket_size: 1
+  max_concurrent_requests: 3
+  retry_parameters:
+    min_backoff_seconds: 5
+    max_backoff_seconds: 300
+    task_age_limit: 3d
+
 # Recidivism Calculation queue
 - name: recidivism-calculator-mr
   mode: push

--- a/recidiviz/ingest/scraper_utils.py
+++ b/recidiviz/ingest/scraper_utils.py
@@ -58,8 +58,8 @@ def parse_date_string(date_string, inmate_id):
             result = parser.parse(date_string)
             result = result.date()
         except ValueError:
-            logging.debug("Couldn't parse date string '%s' for inmate: %s",
-                          date_string, inmate_id)
+            logging.warning("Couldn't parse date string '%s' for inmate: %s",
+                            date_string, inmate_id)
             return None
 
         # If month-only date, manually force date to first of the month.

--- a/recidiviz/ingest/us_vt/__init__.py
+++ b/recidiviz/ingest/us_vt/__init__.py
@@ -15,19 +15,15 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # =============================================================================
 
-"""The ingest portion of the Recidiviz data platform.
+"""us_vt package
 
-This includes infrastructure, logic, and models for ingesting, validating,
-normalizing, and storing records ingested from various criminal justice data
-sources.
+Vermont has a unified jail and prison system, so this package handles
+scraping and storing data of both people who would be in jail and
+prison in another state. In addition, Vermont has information on
+people on probabtion and parole.
+
+Vermont uses the JailTracker system.
+
 """
 
-
-import recidiviz.ingest.docket
-import recidiviz.ingest.models
-import recidiviz.ingest.scraper_control
-import recidiviz.ingest.sessions
-import recidiviz.ingest.tracker
-import recidiviz.ingest.us_ny
-import recidiviz.ingest.us_vt
-import recidiviz.ingest.worker
+from recidiviz.ingest.us_vt import us_vt_scraper

--- a/recidiviz/ingest/us_vt/us_vt_person.py
+++ b/recidiviz/ingest/us_vt/us_vt_person.py
@@ -15,19 +15,26 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 # =============================================================================
 
-"""The ingest portion of the Recidiviz data platform.
-
-This includes infrastructure, logic, and models for ingesting, validating,
-normalizing, and storing records ingested from various criminal justice data
-sources.
+"""Person model for Vermont.
 """
 
 
-import recidiviz.ingest.docket
-import recidiviz.ingest.models
-import recidiviz.ingest.scraper_control
-import recidiviz.ingest.sessions
-import recidiviz.ingest.tracker
-import recidiviz.ingest.us_ny
-import recidiviz.ingest.us_vt
-import recidiviz.ingest.worker
+from google.appengine.ext import ndb
+from recidiviz.models.inmate import Inmate
+
+
+class UsVtPerson(Inmate):
+    """A subclass of Inmate that adds Vermont specific fields
+
+    Datastore model for a specific person incarcerated in
+    Vermont. This extends the Inmate class.
+
+    Attributes:
+
+        us_vt_person_id: (string) Same as person_id, but used as
+            key for this entity type to force uniqueness / prevent
+            collisions within the us_vt records (see
+            models.inmate for inherited attributes)
+
+    """
+    us_vt_person_id = ndb.StringProperty()

--- a/recidiviz/ingest/us_vt/us_vt_record.py
+++ b/recidiviz/ingest/us_vt/us_vt_record.py
@@ -1,0 +1,63 @@
+# Recidiviz - a platform for tracking granular recidivism metrics in real time
+# Copyright (C) 2018 Recidiviz, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# =============================================================================
+
+"""us_vt record-specific functionality.
+"""
+
+
+from google.appengine.ext import ndb
+from recidiviz.models.record import Offense
+
+
+class UsVtOffense(Offense):
+    """UsVt-specific model to describe a particular crime of conviction
+
+    TODO #124 promote non-Vermont specific fields to Charge,
+    Conviction, and Arrest when #124 is closed.
+
+    Attributes:
+        status: (string) The legal status of the charge in court.
+        case_number: (string) Case number of this offense.
+        bond_amount: (float) Dollar amount of bond on this charge, if any.
+        bond_type: (string) How the bond must be secured.
+        number_of_counts: (integer) Counts in this offense.
+        arresting_agency: (string) Name of the agency that arrested this person
+            on this charge.
+        court_type: (string) Type of court that will hear/heard this case.
+        warrant_number: (string) The warrant number for this charge, if any.
+        court_time: (date) Date of the next court appearance.
+        control_number: (string) Unsure what this is.
+        crime_type: (string) Type of crime.
+        arrest_code: (string) Identifier of the arrest event.
+        modifier: (string) Unsure what this is.
+        arrest_date: (date) Date of arrest.
+
+    """
+    status = ndb.StringProperty()
+    case_number = ndb.StringProperty()
+    bond_amount = ndb.FloatProperty()
+    bond_type = ndb.StringProperty()
+    number_of_counts = ndb.IntegerProperty()
+    arresting_agency = ndb.StringProperty()
+    court_type = ndb.StringProperty()
+    warrant_number = ndb.StringProperty()
+    court_time = ndb.DateProperty()
+    control_number = ndb.StringProperty()
+    crime_type = ndb.StringProperty()
+    arrest_code = ndb.StringProperty()
+    modifier = ndb.StringProperty()
+    arrest_date = ndb.DateProperty()

--- a/recidiviz/ingest/us_vt/us_vt_scraper.py
+++ b/recidiviz/ingest/us_vt/us_vt_scraper.py
@@ -1,0 +1,730 @@
+# Recidiviz - a platform for tracking granular recidivism metrics in real time
+# Copyright (C) 2018 Recidiviz, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# =============================================================================
+
+
+"""Scraper implementation for people incarcerated in Vermont.
+
+Region-specific notes:
+
+    - Scrape the front page to get the session key
+    - Make a requests to the GetInmates endpoint N records at a time
+      (say 500) until all rows of the roster have been retrieved.
+    - For each person on the roster, use the ArrestNo in the person's
+      row to grab the GetInmate, GetCases, and GetCharges info.
+    - Create the person and record objects and store them in the datastore.
+
+"""
+
+
+from copy import deepcopy
+import json
+import logging
+import re
+
+from lxml import html
+from lxml.etree import XMLSyntaxError # pylint:disable=no-name-in-module
+
+from google.appengine.ext import ndb
+from google.appengine.ext.db import InternalError
+from google.appengine.ext.db import Timeout, TransactionFailedError
+
+from recidiviz.ingest import scraper_utils
+from recidiviz.ingest.scraper import Scraper
+from recidiviz.ingest.us_vt.us_vt_person import UsVtPerson
+from recidiviz.ingest.us_vt.us_vt_record import UsVtOffense
+from recidiviz.ingest.us_vt.us_vt_snapshot import \
+    UsVtSnapshot
+from recidiviz.models.record import Record
+
+
+class UsVtScraper(Scraper):
+    """Class that scrapes information on people held in Vermont facilities.
+
+    """
+
+    def __init__(self):
+
+        self.front_url = '/jailtracker/index/Vermont'
+        self.roster_url = ('(S({session}))//(S({session}))/JailTracker/'
+                           'GetInmates?start={start}&limit={limit}'
+                           '&sort=LastName&dir=ASC')
+        self.person_url = ('(S({session}))//(S({session}))/JailTracker/'
+                           'GetInmate?arrestNo={arrest}')
+        self.cases_url = ('(S({session}))//(S({session}))/JailTracker/'
+                          'GetCases?arrestNo={arrest}')
+        self.charges_url = ('(S({session}))//(S({session}))/JailTracker/'
+                            'GetCharges')
+
+        super(UsVtScraper, self).__init__('us_vt')
+
+    def get_initial_task(self):
+        """
+        Get the name of the first task to be run.
+
+        Returns:
+            The name of the task to run first.
+
+        """
+        return 'scrape_front_page'
+
+    def scrape_front_page(self, params):
+        """Scrapes the front page for the VT DOC site to get
+        the session key. Enqueues tasks to scrape the roster.
+
+        Args:
+            params: Dict of parameters, includes:
+                scrape_type: 'background' or 'snapshot'
+
+        Returns:
+            Nothing if successful, -1 if fails.
+
+        """
+
+        def get_session_key(html_tree):
+            """Helper function to extract the session key from the html of the
+            front page of the Vermont DOC site.
+
+            """
+
+            # The session key is in a string parameter in a javascript
+            # call that initializes the jailtracker system.
+            body_script = html.tostring(
+                html_tree.xpath("//body/div/script")[0])
+            try:
+                session_key = re.search(
+                    r"JailTracker.Web.Settings.init\('(.*)'",
+                    body_script).group(1)
+            except AttributeError:
+                logging.error("Error, could not parse session key from the "
+                              "front page HTML")
+                return None
+
+            return session_key
+
+        url = '/'.join([self.get_region().base_url, self.front_url])
+        front_page = self.fetch_page(url)
+        if front_page == -1:
+            return -1
+
+        try:
+            front_tree = html.fromstring(front_page.content)
+        except XMLSyntaxError as e:
+            logging.error("Error parsing front page. Error: %s\nPage:\n\n%s",
+                          e, front_page.content)
+            return -1
+
+        session = get_session_key(front_tree)
+        if session is None:
+            return -1
+
+        first_roster_params = {
+            'session': session,
+            'start': 0,
+            'limit': 500,
+            'scrape_type': params['scrape_type']}
+
+        self.add_task('scrape_roster', first_roster_params)
+
+        return None
+
+    def scrape_roster(self, params):
+        """Scrapes the roster for VT to get a list of people. Enqueues tasks
+        to scrape the individual listings.
+
+        Args:
+            params: Dict of parameters, includes:
+                scrape_type: 'background' or 'snapshot'
+                session: (string) session key (required)
+                start: (int) index of the first row of the roster to retrieve
+                       (required)
+                limit: (int) the number of rows to retrieve (required)
+
+        Returns:
+            Nothing if successful, -1 if fails.
+
+        """
+
+        url = '/'.join([self.get_region().base_url, self.roster_url]).format(
+            session=params['session'], start=params['start'],
+            limit=params['limit'])
+
+        roster_response = self.fetch_page(url)
+
+        roster = json.loads(roster_response.content)
+
+        # for termination condition testing and to know which start
+        # row to request next
+        max_row_index = -1
+
+        # add a task for each person in the roster
+        for person in roster['data']:
+            if person['RowIndex'] > max_row_index:
+                max_row_index = person['RowIndex']
+
+            next_person_params = {
+                'session': params['session'],
+                'roster_entry': person,
+                'scrape_type': params['scrape_type']
+            }
+
+            self.add_task('scrape_person', next_person_params)
+
+        # if we aren't done reading the roster, read another page
+        if roster['totalCount'] > max_row_index:
+            next_roster_params = {
+                'start': max_row_index,  # 1- vs. 0-based indexing :(
+                'limit': params['limit'],
+                'session': params['session'],
+                'scrape_type': params['scrape_type']}
+
+            self.add_task('scrape_roster', next_roster_params)
+
+        return None
+
+    def scrape_person(self, params):
+        """Scrape the information about an individual.
+
+        Fetches the general information about an individual, and
+        enqueues the task to scrape the cases information associated
+        with the individual.
+
+        Args:
+            params: Dict of parameters.
+                scrape_type: 'background' or 'snapshot'
+                session: (string) session key (required)
+                roster_entry: (dict) key/value pairs with info contained in
+                    the roster entry
+        """
+
+        url = '/'.join([self.get_region().base_url, self.person_url]).format(
+            session=params['session'],
+            arrest=params['roster_entry']['ArrestNo'])
+        person_response = self.fetch_page(url)
+        person = json.loads(person_response.content)
+
+        cases_params = {
+            'session': params['session'],
+            'roster_entry': params['roster_entry'],
+            'person': person,
+            'scrape_type': params['scrape_type']}
+
+        self.add_task('scrape_cases', cases_params)
+
+
+    def scrape_cases(self, params):
+        """Scrape the case information about an individual case.
+
+        Args:
+            params: Dict of parameters.
+                scrape_type: 'background' or 'snapshot'
+                session: (string) session key (required)
+                roster_entry: (dict) key/value pairs with info contained in
+                    the roster entry
+                person: (dict) key/value pairs with info on the person panel
+        """
+
+        url = '/'.join([self.get_region().base_url, self.cases_url]).format(
+            session=params['session'],
+            arrest=params['roster_entry']['ArrestNo'])
+        cases_response = self.fetch_page(url)
+        cases = json.loads(cases_response.content)
+
+        charges_params = {
+            'session': params['session'],
+            'roster_entry': params['roster_entry'],
+            'person': params['person'],
+            'cases': cases,
+            'scrape_type': params['scrape_type']}
+
+        self.add_task('scrape_charges', charges_params)
+
+    def scrape_charges(self, params):
+        """Scrape the charge information about an individual charge.
+
+        Args:
+            params: Dict of parameters.
+                scrape_type: 'background' or 'snapshot'
+                session: (string) session key (required)
+                roster_entry: (dict) key/value pairs with info contained in
+                    the roster entry
+                person: (dict) key/value pairs with info on the person panel
+                cases: (dict) key/value pairs with info from each of the cases
+                    from the cases list
+
+        """
+
+        url = '/'.join([self.get_region().base_url, self.charges_url]).format(
+            session=params['session'])
+        data = {'arrestNo': params['roster_entry']['ArrestNo']}
+
+        charges_response = self.fetch_page(url, data=data)
+        charges = json.loads(charges_response.content)
+
+        self.store_record(params['roster_entry'], params['person'],
+                          params['cases'], charges)
+
+    @staticmethod
+    def extract_agencies(person_data, person_id):
+        """Get the list of agencies with jurisdiction over this person. There
+        can be more than one agency with jurisdiction if someone is
+        incarcerated but already has a parole agency assigned.
+
+        Args:
+
+            person_data: (list of key/value pairs) The data scraped
+                from the person's detail page.
+
+            person_id: (string) Person identifier for logging purposes.
+
+        Returns:
+
+            A tuple where the first entry is the name of the
+            residential facility with custody over this person (or
+            None) and the second entry is the probation or parole
+            office in charge of supervising this person (or None).
+
+            Returns None on error.
+
+        """
+
+        def is_parole_agency(agency_name):
+            """Guess facility vs. community supervision agency by looking for
+            the string 'parole' in the agency name.
+
+            TODO: #122 find a better way to do this besides looking for a
+            hardcoded string.
+
+            Args:
+
+                agency_name: (string) The name of an agency with
+                    jurisdiction over a person.
+
+            Returns:
+
+                True if the agency is guessed to be a community
+                    supervision agency, False otherwise.
+
+            """
+            return 'parole' in agency_name.lower()
+
+        facility = None
+        parole_agency = None
+
+        # when multiple agencies are present, 'Field' is None for
+        # agencies after the first, but they are sequential.
+        last_was_agency = False  # if the last named field was an agency
+        for entry in person_data:
+            if (last_was_agency and entry['Field'] is None or entry[
+                    'Field'] in ['Agency:', 'Agencies:']):  # Yes, agency
+                last_was_agency = True
+
+                agency_name = entry['Value']
+                # choose between agency type
+                if is_parole_agency(agency_name):
+                    # repeated names happen
+                    if agency_name == parole_agency:
+                        continue
+
+                    # protect against the so-far-unencountered
+                    # situation of multiple distinct community
+                    # supervision agencies.
+                    if parole_agency is not None:
+                        logging.error("Found multiple community supervision "
+                                      "agencies for person id [%s]: [%s, %s]",
+                                      person_id, agency_name, parole_agency)
+                        return None
+
+                    parole_agency = agency_name
+
+                else:
+                    # protect against the so-far-unencountered
+                    # situation of multiple residential facilities.
+                    if facility is not None:
+                        logging.error("Found multiple residential facilites "
+                                      "for person id [%s]: [%s, %s]",
+                                      person_id, agency_name, facility)
+                        return None
+
+                    facility = agency_name
+
+            else:  # Not an agency
+                last_was_agency = False
+
+        return (facility, parole_agency)
+
+    def create_person(self, roster_data, person_data):
+        """Make the person model entity, given data scraped from the roster
+        entry and the person detail page.
+
+        Args:
+
+            roster_data: (list of key/value pairs) information scraped
+                from the person's roster entry.
+
+            person_data: (list of key/value pairs) information scraped
+                from the person's details page.
+
+        Returns:
+
+            Person entity
+
+        """
+        person_id = roster_data['Jacket']
+        person = UsVtPerson.get_or_insert(person_id)
+
+        person.last_name = roster_data['LastName']
+        person.given_names = ' '.join([roster_data['FirstName'],
+                                       roster_data['MiddleName']])
+
+        # Note that we do not try to guess a birthday here, which may
+        # lead to problems with age estimation later.
+        person.age = int(person_data['Current Age'])
+
+        # turn an 'm' or 'f' into a whole word
+        if not person_data['Sex']:
+            person.sex = 'unknown'
+        elif person_data['Sex'].lower()[0] == 'f':
+            person.sex = 'female'
+        elif person_data['Sex'].lower()[0] == 'm':
+            person.sex = 'male'
+        else:
+            person.sex = 'unknown'
+
+        # sometimes race is indicated by letter, but more frequently
+        # it's a whole word. i've not encountered other abbreviations
+        # than 'w' and 'b'.
+        if person_data['Race'].lower() == 'b':
+            person.race = 'black'
+        elif person_data['Race'].lower() == 'w':
+            person.race = 'white'
+        else:
+            person.race = person_data['Race'].lower()
+
+        person.person_id = person_id
+        person.us_vt_person_id = person_id
+        person.person_id_is_fuzzy = True
+        person.region = self.get_region().region_code
+
+        return person
+
+    @staticmethod
+    def create_record(person, agencies, roster_data, person_data,
+                      charge_data):
+        """Make the record model entity, given the person entity and data
+        scraped from several pages.
+
+        Args:
+
+            person: (Person entity) person model entity created from
+                scraped data.
+
+            roster_data: (list of key/value pairs) information scraped
+                from the person's roster entry.
+
+            person_data: (list of key/value pairs) information scraped
+                from the person's details page.
+
+            charge_data: (list of key/value pairs) information scraped
+                from the person's charge details page.
+
+        Returns:
+
+            Record entity
+
+        """
+
+        arrest_no = str(roster_data['ArrestNo'])
+        record = Record.get_or_insert(arrest_no, parent=person.key)
+
+        record.custody_date = scraper_utils.parse_date_string(
+            person_data['Booking Date'], arrest_no)
+
+        # store each charge as an offense to be added to the record
+        record_offenses = []
+        for charge in charge_data:
+            offense = UsVtOffense(
+                arresting_agency=charge['ArrestingAgency'],
+                arrest_code=charge['ArrestCode'],
+                arrest_date=scraper_utils.parse_date_string(
+                    charge['ArrestDate'], arrest_no),
+                bond_amount=charge['BondAmount'],
+                bond_type=charge['BondType'],
+                case_number=charge['CaseNo'],
+                control_number=charge['ControlNumber'],
+                court_time=scraper_utils.parse_date_string(
+                    charge['CourtTime'], arrest_no),
+                court_type=charge['CourtType'],
+                crime_class=str(charge['ChargeId']),
+                crime_description=charge['ChargeDescription'],
+                crime_type=charge['CrimeType'],
+                modifier=charge['Modifier'],
+                number_of_counts=charge['Counts'],
+                status=charge['ChargeStatus'],
+                warrant_number=charge['WarrantNumber'],
+                )
+            record_offenses.append(offense)
+        record.offenses = record_offenses
+
+        record.status = person_data['Status']
+        record.release_date = roster_data['FinalReleaseDateTime']
+        record.earliest_release_date = scraper_utils.parse_date_string(
+            person_data['Min Release'], arrest_no)
+        record.latest_release_date = scraper_utils.parse_date_string(
+            person_data['Max Release'], arrest_no)
+        record.parole_officer = person_data['Parole Officer']
+        record.case_worker = person_data['Case Worker']
+
+        record.sex = person.sex
+        record.race = person.race
+        record.last_name = person.last_name
+        record.given_names = person.given_names
+        record.record_id = str(roster_data['ArrestNo'])
+
+        record.latest_facility = agencies[0]
+        record.community_supervision_agency = agencies[1]
+
+        return record
+
+    def store_record(self, roster_data, person_data, case_data, charge_data):
+        """Store scraped data about a person. This is where information about
+        a person in VT DOC custody is persisted to the datastore.
+
+        We've scraped all incarceration details, and want to store the
+        data we found. This function does some post-processing on the
+        scraped data, and feeds it into the datastore in a way that
+        can be indexed / queried in the future.
+
+        Args:
+            roster_data: (dict) Key/value results parsed from the roster
+            person_data: (dict) Key/value results parsed from the person's page
+            case_data: (dict) Key/value results parsed from the cases page
+            charge_data: (dict) Key/value results parsed from the charges page
+
+        Returns:
+            Nothing if successful, -1 if fails.
+
+        """
+
+        def field_val_pairs_to_dict(field_val_pair):
+            """Convert an array of dict entries where each dict consists of only
+            the fields 'Field' and 'Value' to a dictionary with the
+            values of those fields as the keys and values.
+
+            """
+            items = {}
+            for pair in field_val_pair:
+                field = pair['Field']
+                if field is None:
+                    continue
+                if field.endswith(':'):
+                    field = field[:-1]
+
+                items[field] = pair['Value']
+
+            return items
+
+        agencies = UsVtScraper.extract_agencies(person_data['data'],
+                                                roster_data['Jacket'])
+        person_data = field_val_pairs_to_dict(person_data['data'])
+        charge_data = charge_data['data']
+
+        # So far, all case data has been empty. Check for non-empty
+        # case data and log an error so we know to investigate what
+        # should be stored.
+        case_data = case_data['data']
+        if case_data:
+            logging.error("Non-empty case data found, inspect it and "
+                          "investigate storing the info it contains.\n"
+                          "%r", case_data)
+
+        # create the person and persist them
+        person = self.create_person(roster_data, person_data)
+
+        try:
+            person.put()
+        except (Timeout, TransactionFailedError, InternalError):
+            # Datastore error - fail task to trigger queue retry + backoff
+            logging.warning("Couldn't persist person: %s", person.person_id)
+            return -1
+
+        # create the record and persist it.
+        record = UsVtScraper.create_record(
+            person, agencies, roster_data, person_data, charge_data)
+
+        try:
+            record.put()
+        except (Timeout, TransactionFailedError, InternalError):
+            logging.warning("Couldn't persist record: %s", record.record_id)
+            return -1
+
+        # create a snapshot from the record so we only store what's
+        # changed since the last scrape.
+        old_record = deepcopy(record)
+        new_snapshot = self.record_to_snapshot(record)
+        self.compare_and_set_snapshot(old_record, new_snapshot)
+
+        return None
+
+    # pylint:disable=arguments-differ
+    def inmate_id_to_record_id(self, person_id):
+        """Convert provided person_id to record_id of any record for that
+        person. This is the implementation of an abstract method in Scraper.
+
+        Args:
+            person_id: (string) Person ID for the person
+
+        Returns:
+            None if query returns None
+            Record ID if a record is found for the person in the docket item
+
+        """
+        person = UsVtPerson.query(UsVtPerson.person_id == person_id).get()
+        if not person:
+            return None
+
+        record = Record.query(ancestor=person.key).get()
+        if not record:
+            return None
+
+        return record.record_id
+
+    def record_to_snapshot(self, record):
+        """Mirrors record fields into a Snapshot instance
+
+        Takes in a new Record entity, and mirrors its fields into a
+        Snapshot entity for comparison against the last-collected
+        snapshot entity for this Record.
+
+        Args:
+            record: A Record object to mirror
+
+        Returns:
+            A Snapshot entity populated with the same details as the Record
+
+        """
+        snapshot = UsVtSnapshot(
+            birthday=record.birthday,
+            case_worker=record.case_worker,
+            community_supervision_agency=record.community_supervision_agency,
+            custody_date=record.custody_date,
+            given_names=record.given_names,
+            is_released=record.is_released,
+            last_name=record.last_name,
+            latest_facility=record.latest_facility,
+            latest_release_date=record.latest_release_date,
+            latest_release_type=record.latest_release_type,
+            max_sentence_length=record.max_sentence_length,
+            min_sentence_length=record.min_sentence_length,
+            offense=record.offense,
+            parent=record.key,
+            parole_officer=record.parole_officer,
+            race=record.race,
+            release_date=record.release_date,
+            sex=record.sex,
+            status=record.status,
+        )
+
+        return snapshot
+
+    def compare_and_set_snapshot(self, old_record, snapshot):
+        """Check for updates since last scrape, if found persist new snapshot
+        Checks the last snapshot taken for this record, and if fields
+        have changed since the last time the record was updated (or
+        the record has no old snapshots) stores new snapshot.
+
+        TODO: #121 this function should be abstracted into the Scraper class.
+
+        The new snapshot will only include those fields which have changed.
+        Args:
+            old_record: (UsVtRecord) The record entity this
+                snapshot pertains to
+            snapshot: (UsVtSnapshot) Snapshot object with details from
+                current scrape.
+        Returns:
+            True if successful
+            False if datastore errors
+
+        """
+        new_snapshot = False
+
+        # pylint:disable=protected-access
+        snapshot_class = ndb.Model._kind_map['UsVtSnapshot']
+        snapshot_attrs = snapshot_class._properties
+
+        last_snapshot = UsVtSnapshot.query(
+            ancestor=old_record.key).order(
+                -UsVtSnapshot.created_on).get()
+
+        if last_snapshot:
+            for attribute in snapshot_attrs:
+                if attribute not in ["class", "created_on", "offense"]:
+                    current_value = getattr(snapshot, attribute)
+                    last_value = getattr(old_record, attribute)
+                    if current_value != last_value:
+                        new_snapshot = True
+                        logging.info("Found change in person snapshot: field "
+                                     "%s was '%s', is now '%s'.",
+                                     attribute, last_value, current_value)
+                    else:
+                        setattr(snapshot, attribute, None)
+
+                elif attribute == "offense":
+                    # Offenses have to be treated differently -
+                    # setting them to None means an empty list or
+                    # tuple instead of None, and an unordered list of
+                    # them can't be compared to another unordered list
+                    # of them.
+                    #
+                    # TODO #123 instead of storing the entire list if
+                    # anything has changed, do a smarter diff on the
+                    # nested fields.
+                    offense_changed = False
+
+                    # Check if any new offenses have been added
+                    for charge in snapshot.offense:
+                        if charge in old_record.offense:
+                            pass
+                        else:
+                            offense_changed = True
+
+                    # Check if any old offenses have been removed
+                    for charge in old_record.offense:
+                        if charge in snapshot.offense:
+                            pass
+                        else:
+                            offense_changed = True
+
+                    if offense_changed:
+                        new_snapshot = True
+                        logging.info("Found change in person snapshot: field "
+                                     "%s was '%s', is now '%s'.", attribute,
+                                     old_record.offense, snapshot.offense)
+                    else:
+                        setattr(snapshot, attribute, [])
+
+        else:
+            # This is the first snapshot, store everything
+            new_snapshot = True
+
+        if new_snapshot:
+            try:
+                snapshot.put()
+            except (Timeout, TransactionFailedError, InternalError):
+                logging.warning("Couldn't store new snapshot for record %s",
+                                old_record.record_id)
+
+        return True

--- a/recidiviz/ingest/us_vt/us_vt_snapshot.py
+++ b/recidiviz/ingest/us_vt/us_vt_snapshot.py
@@ -1,0 +1,48 @@
+# Recidiviz - a platform for tracking granular recidivism metrics in real time
+# Copyright (C) 2018 Recidiviz, Inc.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+# =============================================================================
+
+"""us_vt snapshot-specific functionality
+"""
+
+from google.appengine.ext import ndb
+from recidiviz.models.snapshot import Snapshot
+
+
+class UsVtSnapshot(Snapshot):
+    """A subclass of Snapshot that adds New York specific fields
+
+    Datastore model for the New York-specific fields in snapshots of inmate
+    information. Snapshots are generated each time the scraper runs and
+    finds a property of an Inmate or Record entity has changed in the
+    corrections system. Only that attribute (and any others which have changed
+    since the last scrape) is stored in the snapshot.
+
+    UsVtSnapshot entities are stored as children of their
+    respective record entities. There may be multiple snapshots per
+    record.
+
+    Attributes:
+        (see us_vt_record.py for attributes)
+        (see models.snapshot for inherited attributes)
+
+    """
+    status = ndb.StringProperty()
+    release_date = ndb.DateProperty()
+    earliest_release_date = ndb.DateProperty()
+    community_supervision_agency = ndb.StringProperty()
+    parole_officer = ndb.StringProperty()
+    case_worker = ndb.StringProperty()

--- a/recidiviz/models/inmate.py
+++ b/recidiviz/models/inmate.py
@@ -45,6 +45,8 @@ class Inmate(polymodel.PolyModel):
         given_names: (string) First and middle names (space separated),
             if available
         last_name: (string) Last name, if provided
+        suffix: (string) Suffix portion of the person's name.
+        alias: (string) Alias(es) known to be used by this person.
         birthday: (date) Birth date, if available
         age: (int) Age, if birth date is not available.
         region: (string) The region code for the scraper that captured this
@@ -60,6 +62,8 @@ class Inmate(polymodel.PolyModel):
     inmate_id_is_fuzzy = ndb.BooleanProperty()
     given_names = ndb.StringProperty()
     last_name = ndb.StringProperty()
+    suffix = ndb.StringProperty()
+    alias = ndb.StringProperty()
     birthday = ndb.DateProperty()
     age = ndb.IntegerProperty()
     region = ndb.StringProperty()

--- a/recidiviz/models/record.py
+++ b/recidiviz/models/record.py
@@ -87,27 +87,44 @@ class Record(polymodel.PolyModel):
         created_on: (datetime) Creation date of this record. If data is
             migrated in the future, effort will be made to preserve this field
         updated_on: (date) Date of last change / update to this record
+        status: (string) Status of the person at this time (sentenced,
+            detained, released, etc.)
         offense: (record.Offense) State-provided strings describing the crimes
             of conviction and (if available) class of crimes.
         record_id: (string) The identifier the state site uses for this crime
+        given_names: (string) Any given names provided by the source
+        last_name: (string) The inmate's surname, as provided by the source
+        birthday: (date) Date of birth for the inmate as provided by the source
+        sex: (string) Sex of the prisoner as provided by the prison system
+        race: (string) Race of the prisoner as provided by prison system
         min_sentence: (record.SentenceDuration) Minimum sentence to be served
         max_sentence: (record.SentenceDuration) Maximum sentence to be served
         custody_date: (date) Date the inmate's sentence started
         offense_date: (date) Date the offense was committed
         latest_facility: (string) The name of the most recent facility the
             inmate has been held in
+        release_date: (date) Date of actual release.
+        earliest_release_date: (date) Earliest date release is possible.
         latest_release_date: (date) Most recent date of release
         latest_release_type: (string) Reason given for most recent release
         is_released: (bool) Whether the inmate has been released from this
             sentence
-        given_names: (string) Any given names provided by the source
-        last_name: (string) The inmate's surname, as provided by the source
-        birthday: (date) Date of birth for the inmate as provided by the source
-        sex: (string) Sex of the prisoner as provided by the prison system
-        race: (string) Race of the prisoner as provided by prison system
+        earliest_release_date: (date) Earliest date to be released based on
+            min_sentence. In certain circumstances, may be released before
+            this.
+        community_supervision_agency: (string) The parole or probation office
+            that does or will have jurisdiction over this person after release.
+        parole_officer: (string) Name of the parole officer.
+        case_worker: (string) Name of the case worker.
     """
+    status = ndb.StringProperty()
     offense = ndb.StructuredProperty(Offense, repeated=True)
     record_id = ndb.StringProperty()
+    given_names = ndb.StringProperty()
+    last_name = ndb.StringProperty()
+    birthday = ndb.DateProperty()
+    sex = ndb.StringProperty()
+    race = ndb.StringProperty()
     min_sentence_length = ndb.StructuredProperty(SentenceDuration,
                                                  repeated=False)
     max_sentence_length = ndb.StructuredProperty(SentenceDuration,
@@ -115,13 +132,13 @@ class Record(polymodel.PolyModel):
     custody_date = ndb.DateProperty()
     offense_date = ndb.DateProperty()
     latest_facility = ndb.StringProperty()
+    release_date = ndb.DateProperty()
+    earliest_release_date = ndb.DateProperty()
     latest_release_date = ndb.DateProperty()
     latest_release_type = ndb.StringProperty()
     is_released = ndb.BooleanProperty()
-    given_names = ndb.StringProperty()
-    last_name = ndb.StringProperty()
-    birthday = ndb.DateProperty()
-    sex = ndb.StringProperty()
-    race = ndb.StringProperty()
+    community_supervision_agency = ndb.StringProperty()
+    parole_officer = ndb.StringProperty()
+    case_worker = ndb.StringProperty()
     created_on = ndb.DateTimeProperty(auto_now_add=True)
     updated_on = ndb.DateProperty(auto_now=True)

--- a/recidiviz/tests/ingest/scraper_control_test.py
+++ b/recidiviz/tests/ingest/scraper_control_test.py
@@ -44,7 +44,7 @@ def test_get_and_validate_params_all():
     params = [("region", "all"), ("scrape_type", "all")]
 
     results = scraper_control.get_and_validate_params(params)
-    assert results == (["us_ny"], ["background", "snapshot"], params)
+    assert results == (["us_ny", "us_vt"], ["background", "snapshot"], params)
 
 
 def test_get_and_validate_params_invalid_region():

--- a/region_manifest.yaml
+++ b/region_manifest.yaml
@@ -33,3 +33,18 @@ regions:
     region_name: New York State
     scraper_package: us_ny
     timezone: America/New_York
+  us_vt:
+    region_name: UsVt
+    agency_name: Vermont Department of Corrections
+    region_code: us_vt
+    agency_type: unified
+    queues:
+    - us-vt-scraper
+    base_url: https://omsweb.public-safety-cloud.com/jtclientweb
+    names_file: us_ny_names.csv
+    entity_kinds:
+      inmate: UsVtInmate
+      record: UsVtRecord
+      snapshot: UsVtSnapshot
+    scraper_package: us_vt
+    timezone: America/New_York


### PR DESCRIPTION
This addresses issue #115. It adds a scraper that ingests the unified jail and prison system of the state of Vermont. That jurisdiction uses JailTracker, so this commit can be the basis for future JailTracker scrapers. 

* Create a `us_vt` directory in ingest
  - Fill with classes to handle the scraping and models for UsVt
  - This jurisdiction uses JailTracker, so this commit can serve as a
    basis for future jurisdictions that use the JailTracker system.

* Update the web app configuration to add queues for scraping `us_vt`.

* Update a test to include the new 'us_vt' region in the list of all
  expected regions.